### PR TITLE
Update README.md

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -1,5 +1,5 @@
 # Introduction
 
-Most software projects deal with monetary values. Primitive types like `Float` and `Double` or richer types like `BigDecimal` are sometimes used to represent monetary values. On the other hand, we often develop or use third-party APIs that offer abstraction for representing money. So clearly it's a very common problem that requires a common standard.
+Most software projects deal with monetary values. Primitive wrappers like `Float` and `Double` or richer types like `BigDecimal` are sometimes used to represent monetary values. On the other hand, we often develop or use third-party APIs that offer abstraction for representing money. So clearly it's a very common problem that requires a common standard.
 
 The **JSR 354** (Money and Currency API) is a work towards defining an API that provides abstraction for  money and currency.


### PR DESCRIPTION
Replaced "types" with "wrappers" since **Float** is not a primitive type, **float** would be.
